### PR TITLE
Fix memory management of `basis_data`

### DIFF
--- a/include/ads/basis_data.hpp
+++ b/include/ads/basis_data.hpp
@@ -37,6 +37,8 @@ struct basis_data {
 
     ~basis_data();
 
+    basis_data(const basis_data& other);
+
     basis_data(bspline::basis basis, int derivatives)
     : basis_data{std::move(basis), derivatives, basis.degree + 1, 1} { }
 

--- a/include/ads/basis_data.hpp
+++ b/include/ads/basis_data.hpp
@@ -25,6 +25,7 @@ struct basis_data {
     int degree;
     int elements;
     int dofs;
+    int derivatives;
     int quad_order;
     int elem_division;
     std::vector<double> points;
@@ -33,6 +34,8 @@ struct basis_data {
     double** x;
     const double* w;
     double* J;
+
+    ~basis_data();
 
     basis_data(bspline::basis basis, int derivatives)
     : basis_data{std::move(basis), derivatives, basis.degree + 1, 1} { }

--- a/src/ads/basis_data.cpp
+++ b/src/ads/basis_data.cpp
@@ -8,12 +8,29 @@
 
 namespace ads {
 
+basis_data::~basis_data() {
+    for (int e = 0; e < elements; ++e) {
+        for (int k = 0; k < quad_order; ++k) {
+            for (int d = 0; d <= derivatives; ++d) {
+                delete[] b[e][k][d];
+            }
+            delete[] b[e][k];
+        }
+        delete[] b[e];
+        delete[] x[e];
+    }
+    delete[] b;
+    delete[] J;
+    delete[] x;
+}
+
 basis_data::basis_data(bspline::basis basis, int derivatives, int quad_order, int elem_division)
 : first_dofs(bspline::first_nonzero_dofs(basis))
 , element_ranges(bspline::elements_supporting_dofs(basis))
 , degree(basis.degree)
 , elements(basis.elements() * elem_division)
 , dofs(basis.dofs())
+, derivatives(derivatives)
 , quad_order(quad_order)
 , elem_division(elem_division)
 , points(elements + 1)

--- a/src/ads/basis_data.cpp
+++ b/src/ads/basis_data.cpp
@@ -24,6 +24,42 @@ basis_data::~basis_data() {
     delete[] x;
 }
 
+basis_data::basis_data(const basis_data& other)
+: first_dofs{other.first_dofs}
+, element_ranges{other.element_ranges}
+, degree{other.degree}
+, elements{other.elements}
+, dofs{other.dofs}
+, derivatives{other.derivatives}
+, quad_order{other.quad_order}
+, elem_division{other.elem_division}
+, points{other.points}
+, basis{other.basis}
+, b{new double***[elements]}
+, x{new double*[elements]}
+, w{other.w}
+, J{new double[elements]} {
+    for (int e = 0; e < elements; ++e) {
+        x[e] = new double[quad_order];
+        b[e] = new double**[quad_order];
+
+        for (int k = 0; k < quad_order; ++k) {
+            x[e][k] = other.x[e][k];
+            b[e][k] = new double*[derivatives + 1];
+
+            for (int d = 0; d <= derivatives; ++d) {
+                b[e][k][d] = new double[degree + 1];
+
+                for (int i = 0; i < degree + 1; ++i) {
+                    b[e][k][d][i] = other.b[e][k][d][i];
+                }
+            }
+        }
+
+        J[e] = other.J[e];
+    }
+}
+
 basis_data::basis_data(bspline::basis basis, int derivatives, int quad_order, int elem_division)
 : first_dofs(bspline::first_nonzero_dofs(basis))
 , element_ranges(bspline::elements_supporting_dofs(basis))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(ads-suite
     main.cpp
     ads/bspline/bspline_test.cpp
     ads/bspline/eval_test.cpp
+    ads/basis_data_test.cpp
     ads/util/multi_array_test.cpp
     ads/lin/band_solve_test.cpp
     ads/lin/dense_solve_test.cpp

--- a/tests/ads/basis_data_test.cpp
+++ b/tests/ads/basis_data_test.cpp
@@ -10,4 +10,15 @@
 TEST_CASE("basis_data memory management") {
     auto basis = ads::bspline::create_basis(0.0, 1.0, 2, 5);
     auto data = ads::basis_data{basis, 1};
+
+    SECTION("can be copied") {
+        auto copy = data;
+
+        REQUIRE(copy.degree == data.degree);
+        REQUIRE(copy.elements == data.elements);
+        REQUIRE(copy.dofs == data.dofs);
+        REQUIRE(copy.derivatives == data.derivatives);
+        REQUIRE(copy.quad_order == data.quad_order);
+        REQUIRE(copy.elem_division == data.elem_division);
+    }
 }

--- a/tests/ads/basis_data_test.cpp
+++ b/tests/ads/basis_data_test.cpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2015 - 2021 Marcin Łoś <marcin.los.91@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "ads/basis_data.hpp"
+
+#include <catch2/catch.hpp>
+
+#include "ads/bspline/bspline.hpp"
+
+TEST_CASE("basis_data memory management") {
+    auto basis = ads::bspline::create_basis(0.0, 1.0, 2, 5);
+    auto data = ads::basis_data{basis, 1};
+}


### PR DESCRIPTION
Adding destructor and copy constructor for `ads::basis_data` prevents memory leaks and crashes when copying. Ultimately, manual memory management should be replaced by a proper multidimensional array.

Closes #13