### PR TITLE
Add Coverity Scan workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,7 @@
 name: Coverity scan
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 1 * * *' # Daily at 01:00 UTC
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,56 @@
+name: Coverity scan
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # Daily at 01:00 UTC
+
+env:
+  BUILD_PREFIX: ~/_build
+  INSTALL_PREFIX: ~/_install
+
+jobs:
+  coverity-scan:
+    name: Coverity scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Coverity Scan Tool
+        run: scripts/coverity-download.sh
+        env:
+          TOKEN: ${{ secrets.COVERITY_TOKEN }}
+
+
+      - name: Prepare for building
+        id: prepare
+        uses: ./.github/actions/prepare
+        with:
+          cxx: Clang-12
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        id: cache-libs
+        with:
+          path: ${{ env.INSTALL_PREFIX }}
+          key: libs-${{ steps.prepare.outputs.cxx-family }}
+
+      - name: Build dependencies
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: scripts/install-dependencies.sh ${BUILD_PREFIX} ${INSTALL_PREFIX}
+
+      - name: Configure
+        uses: ./.github/actions/configure
+        with:
+          build-type: Debug
+          use-galois: ON
+          use-mumps: ON
+
+      - name: Build with cov-build
+        run: cov-build --dir cov-int cmake --build build
+
+      - name: Submit results
+        run: scripts/coverity-submit.sh
+        env:
+          TOKEN: ${{ secrets.COVERITY_TOKEN }}

--- a/scripts/coverity-download.sh
+++ b/scripts/coverity-download.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Download Coverity Scan Tool
+wget -q https://scan.coverity.com/download/cxx/linux64 \
+    --post-data "token=${TOKEN}&project=marcinlos/iga-ads" \
+    -O coverity.tgz
+
+# Extract into a directory with simple name
+DIR=coverity
+
+mkdir -p "${DIR}"
+
+tar xzf coverity.tgz \
+    --strip-components 1 \
+    --directory "${DIR}"
+
+# Ensure cov-build is on $PATH
+echo "PATH=$(readlink -f ${DIR}/bin):${PATH}" >> "${GITHUB_ENV}"

--- a/scripts/coverity-submit.sh
+++ b/scripts/coverity-submit.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+FILE="scan-data.tgz"
+
+tar czf "${FILE}" build/cov-init
+
+curl \
+    --form project=marcinlos/iga-ads \
+    --form token=${TOKEN} \
+    --form email=marcin.los.91@gmail.com \
+    --form file=${FILE} \
+    --form version=develop \
+    --form description="develop build" \
+    https://scan.coverity.com/builds


### PR DESCRIPTION
This adds a Github Actions workflow that submits a build to Coverity Scan daily.

Closes #45