### PR TITLE
Add Coverity Scan workflow (v2)

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,59 @@
+name: Coverity scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * 1' # Every Monday at 01:00 UTC
+
+env:
+  BUILD_PREFIX: ~/_build
+  INSTALL_PREFIX: ~/_install
+
+jobs:
+  coverity-scan:
+    name: Coverity scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Coverity Scan Tool
+        run: scripts/coverity-download.sh
+        env:
+          TOKEN: ${{ secrets.COVERITY_TOKEN }}
+
+
+      - name: Prepare for building
+        id: prepare
+        uses: ./.github/actions/prepare
+        with:
+          cxx: Clang-12
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        id: cache-libs
+        with:
+          path: ${{ env.INSTALL_PREFIX }}
+          key: libs-${{ steps.prepare.outputs.cxx-family }}
+
+      - name: Build dependencies
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: scripts/install-dependencies.sh ${BUILD_PREFIX} ${INSTALL_PREFIX}
+
+      - name: Configure
+        uses: ./.github/actions/configure
+        with:
+          build-type: Debug
+          use-galois: ON
+          use-mumps: ON
+
+      - name: Build with cov-build
+        working-directory: build
+        run: cov-build --dir cov-int cmake --build .
+
+      - name: Submit results
+        working-directory: build
+        run: ${{ github.workspace }}/scripts/coverity-submit.sh
+        env:
+          TOKEN: ${{ secrets.COVERITY_TOKEN }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -52,6 +52,12 @@ jobs:
         working-directory: build
         run: cov-build --dir cov-int cmake --build .
 
+      - name: Upload Coverity build log
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverity-log.txt
+          path: build/cov-int/build-log.txt
+
       - name: Submit results
         working-directory: build
         run: ${{ github.workspace }}/scripts/coverity-submit.sh

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Build with cov-build
         working-directory: build
-        run: cov-build --dir cov-int cmake --build .
+        run: |
+          cov-configure --comptype gcc --template --compiler g++-9
+          cov-build --dir cov-int cmake --build .
 
       - name: Upload Coverity build log
         uses: actions/upload-artifact@v2

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -28,7 +28,7 @@ jobs:
         id: prepare
         uses: ./.github/actions/prepare
         with:
-          cxx: Clang-12
+          cxx: GCC-9
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/scripts/coverity-download.sh
+++ b/scripts/coverity-download.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Download Coverity Scan Tool
+wget -q https://scan.coverity.com/download/cxx/linux64 \
+    --post-data "token=${TOKEN}&project=marcinlos/iga-ads" \
+    -O coverity.tgz
+
+# Extract into a directory with simple name
+DIR=coverity
+
+mkdir -p "${DIR}"
+
+tar xzf coverity.tgz \
+    --strip-components 1 \
+    --directory "${DIR}"
+
+# Ensure cov-build is on $PATH
+echo "PATH=$(readlink -f ${DIR}/bin):${PATH}" >> "${GITHUB_ENV}"

--- a/scripts/coverity-submit.sh
+++ b/scripts/coverity-submit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eux
+
+FILE="scan-data.tgz"
+
+tar czf "${FILE}" cov-int
+
+curl \
+    --form token=${TOKEN} \
+    --form email=marcin.los.91@gmail.com \
+    --form file=@${FILE} \
+    --form version=${GITHUB_SHA} \
+    --form description="develop build" \
+    https://scan.coverity.com/builds?project=marcinlos%2Figa-ads


### PR DESCRIPTION
Previous PR #50 was insufficient, as there was no way to test if Coverity integration works before merging it. This one has been properly tested on `develop`.