### PR TITLE
Fix relative error being multiplied by 100 two times

### DIFF
--- a/examples/multistep/multistep3d.hpp
+++ b/examples/multistep/multistep3d.hpp
@@ -298,11 +298,11 @@ private:
     }
 
     double errorL2(const vector_type& u, double t) const {
-        return error_relative(u, x, y, z, L2{}, exact(t));
+        return error_relative(u, x, y, z, L2{}, exact(t)) * 100;
     }
 
     double errorH1(const vector_type& u, double t) const {
-        return error_relative(u, x, y, z, H1{}, exact(t));
+        return error_relative(u, x, y, z, H1{}, exact(t)) * 100;
     }
 
     // Problem definition

--- a/include/ads/simulation/basic_simulation_2d.hpp
+++ b/include/ads/simulation/basic_simulation_2d.hpp
@@ -352,7 +352,7 @@ protected:
     template <typename Sol, typename Fun, typename Norm>
     double error_relative(const Sol& u, const dimension& Ux, const dimension& Uy, Norm&& norm,
                           Fun&& fun) const {
-        return error(u, Ux, Uy, norm, fun) / this->norm(Ux, Uy, norm, fun) * 100;
+        return error(u, Ux, Uy, norm, fun) / this->norm(Ux, Uy, norm, fun);
     }
 
     template <typename Sol, typename Fun>


### PR DESCRIPTION
This makes the `relative_error` return a number in range `[0, 1]` and fixes inappropriate usage in `multistep3d`.

Closes #60 