### PR TITLE
Simplify multistep higher-order correction

### DIFF
--- a/examples/multistep/multistep2d.hpp
+++ b/examples/multistep/multistep2d.hpp
@@ -120,32 +120,12 @@ private:
         }
     }
 
-    double eval_basis_dxy(index_type e, index_type q, index_type a) const {
-        auto loc = dof_global_to_local(e, a);
-        const auto& bx = x.basis;
-        const auto& by = y.basis;
-        double dB1 = bx.b[e[0]][q[0]][1][loc[0]];
-        double dB2 = by.b[e[1]][q[1]][1][loc[1]];
-        return dB1 * dB2;
-    }
-
-    double eval_fun_dxy(const vector_type& v, index_type e, index_type q) const {
-        double u = 0;
-        for (auto b : dofs_on_element(e)) {
-            double c = v(b[0], b[1]);
-            double B = eval_basis_dxy(e, q, b);
-            u += c * B;
-        }
-        return u;
-    }
-
     void compute_rhs(vector_type& rhs, double t) {
         zero(rhs);
 
         executor.for_each(elements(), [&](index_type e) {
             auto U = element_rhs();
             std::vector<value_type> uvals(us.size());
-            std::vector<double> dxy(us.size());
 
             double tau = steps.dt;
             double tt = t + tau;
@@ -158,13 +138,11 @@ private:
 
                 for (int i = 1; i < us.size(); ++i) {
                     uvals[i] = eval_fun(us[i], e, q);
-                    dxy[i] = eval_fun_dxy(us[i], e, q);
                 }
 
                 for (auto a : dofs_on_element(e)) {
                     auto aa = dof_global_to_local(e, a);
                     value_type v = eval_basis(e, q, a);
-                    double vxy = eval_basis_dxy(e, q, a);
 
                     double val = 0;
 

--- a/examples/multistep/multistep2d.hpp
+++ b/examples/multistep/multistep2d.hpp
@@ -70,13 +70,6 @@ private:
         prepare_spaces();
         prepare_matrices();
 
-        // Single initial step is enough only for two-step methods
-
-        // auto init = [this](double x, double y) { return init_state(x, y); };
-        // projection(us[0], init);
-        // apply_bc(us[0]);
-        // solve(us[0]);
-
         int needed = us.size() - 1;
         for (int i = 0; i < needed; ++i) {
             double t = i * steps.dt;
@@ -86,8 +79,6 @@ private:
             apply_bc(us[0]);
             solve(us[0]);
 
-            // std::cout << "Initial state " << t << " ";
-            // print_errors(us[0], t);
             us.rotate();
         }
         us.rotate();
@@ -228,8 +219,6 @@ private:
                           e * M_PI * std::cos(x * M_PI) * std::sin(y * M_PI),
                           e * M_PI * std::sin(x * M_PI) * std::cos(y * M_PI)};
     }
-
-    double init_state(double x, double y) const { return solution(x, y, 0).val; }
 };
 
 }  // namespace ads::problems

--- a/examples/multistep/multistep3d.hpp
+++ b/examples/multistep/multistep3d.hpp
@@ -130,108 +130,12 @@ private:
         }
     }
 
-    double eval_basis_dxy(index_type e, index_type q, index_type a) const {
-        auto loc = dof_global_to_local(e, a);
-        const auto& bx = x.basis;
-        const auto& by = y.basis;
-        const auto& bz = z.basis;
-
-        double dB1 = bx.b[e[0]][q[0]][1][loc[0]];
-        double dB2 = by.b[e[1]][q[1]][1][loc[1]];
-        double B3 = bz.b[e[2]][q[2]][0][loc[2]];
-
-        return dB1 * dB2 * B3;
-    }
-
-    double eval_basis_dyz(index_type e, index_type q, index_type a) const {
-        auto loc = dof_global_to_local(e, a);
-        const auto& bx = x.basis;
-        const auto& by = y.basis;
-        const auto& bz = z.basis;
-
-        double B1 = bx.b[e[0]][q[0]][0][loc[0]];
-        double dB2 = by.b[e[1]][q[1]][1][loc[1]];
-        double dB3 = bz.b[e[2]][q[2]][1][loc[2]];
-
-        return B1 * dB2 * dB3;
-    }
-
-    double eval_basis_dxz(index_type e, index_type q, index_type a) const {
-        auto loc = dof_global_to_local(e, a);
-        const auto& bx = x.basis;
-        const auto& by = y.basis;
-        const auto& bz = z.basis;
-
-        double dB1 = bx.b[e[0]][q[0]][1][loc[0]];
-        double B2 = by.b[e[1]][q[1]][0][loc[1]];
-        double dB3 = bz.b[e[2]][q[2]][1][loc[2]];
-
-        return dB1 * B2 * dB3;
-    }
-
-    double eval_basis_dxyz(index_type e, index_type q, index_type a) const {
-        auto loc = dof_global_to_local(e, a);
-        const auto& bx = x.basis;
-        const auto& by = y.basis;
-        const auto& bz = z.basis;
-
-        double dB1 = bx.b[e[0]][q[0]][1][loc[0]];
-        double dB2 = by.b[e[1]][q[1]][1][loc[1]];
-        double dB3 = bz.b[e[2]][q[2]][1][loc[2]];
-
-        return dB1 * dB2 * dB3;
-    }
-
-    double eval_fun_dxy(const vector_type& v, index_type e, index_type q) const {
-        double u = 0;
-        for (auto b : dofs_on_element(e)) {
-            double c = v(b[0], b[1], b[2]);
-            double B = eval_basis_dxy(e, q, b);
-            u += c * B;
-        }
-        return u;
-    }
-
-    double eval_fun_dyz(const vector_type& v, index_type e, index_type q) const {
-        double u = 0;
-        for (auto b : dofs_on_element(e)) {
-            double c = v(b[0], b[1], b[2]);
-            double B = eval_basis_dyz(e, q, b);
-            u += c * B;
-        }
-        return u;
-    }
-
-    double eval_fun_dxz(const vector_type& v, index_type e, index_type q) const {
-        double u = 0;
-        for (auto b : dofs_on_element(e)) {
-            double c = v(b[0], b[1], b[2]);
-            double B = eval_basis_dxz(e, q, b);
-            u += c * B;
-        }
-        return u;
-    }
-
-    double eval_fun_dxyz(const vector_type& v, index_type e, index_type q) const {
-        double u = 0;
-        for (auto b : dofs_on_element(e)) {
-            double c = v(b[0], b[1], b[2]);
-            double B = eval_basis_dxyz(e, q, b);
-            u += c * B;
-        }
-        return u;
-    }
-
     void compute_rhs(vector_type& rhs, double t) {
         zero(rhs);
 
         executor.for_each(elements(), [&](index_type e) {
             auto U = element_rhs();
             std::vector<value_type> uvals(us.size());
-            std::vector<double> dxy(us.size());
-            std::vector<double> dyz(us.size());
-            std::vector<double> dxz(us.size());
-            std::vector<double> dxyz(us.size());
 
             double tau = steps.dt;
             double tt = t + tau;
@@ -244,19 +148,11 @@ private:
 
                 for (int i = 1; i < us.size(); ++i) {
                     uvals[i] = eval_fun(us[i], e, q);
-                    dxy[i] = eval_fun_dxy(us[i], e, q);
-                    dyz[i] = eval_fun_dyz(us[i], e, q);
-                    dxz[i] = eval_fun_dxz(us[i], e, q);
-                    dxyz[i] = eval_fun_dxyz(us[i], e, q);
                 }
 
                 for (auto a : dofs_on_element(e)) {
                     auto aa = dof_global_to_local(e, a);
                     value_type v = eval_basis(e, q, a);
-                    double vxy = eval_basis_dxy(e, q, a);
-                    double vyz = eval_basis_dyz(e, q, a);
-                    double vxz = eval_basis_dxz(e, q, a);
-                    double vxyz = eval_basis_dxyz(e, q, a);
 
                     double val = 0;
 

--- a/examples/multistep/multistep3d.hpp
+++ b/examples/multistep/multistep3d.hpp
@@ -104,6 +104,8 @@ private:
         apply_bc(us[0]);
 
         ads_solve(us[0], buffer, dim_data{Ax, Ax_ctx}, dim_data{Ay, Ay_ctx}, dim_data{Az, Az_ctx});
+
+        adjust_solution(us);
     }
 
     void after() override {
@@ -262,18 +264,23 @@ private:
                         double ti = tt - i * tau;
                         val += tau * bs[i] * force(x, ti) * v.val;
                     }
+
+                    auto const form = [this](auto u, auto v) { return grad_dot(u, v); };
+
                     for (int i = 1; i <= s; ++i) {
                         auto u = uvals[i];
-                        val -= as[i - 1] * u.val * v.val + tau * bs[i] * grad_dot(u, v);
+                        val -= as[i - 1] * u.val * v.val + tau * bs[i] * form(u, v);
                     }
                     if (s == 0) {
                         val -= as[s] * uvals[s + 1].val * v.val;
                     }
 
                     // Correction to get higher order
+                    // We apply M + eta K to solutions from previous time steps and add it
+                    // to RHS, multiplied by finite difference coefficients
                     for (int i = 1; i < order; ++i) {
-                        val -= fibo[i] * eta * eta * (dxy[i] * vxy + dxz[i] * vxz + dyz[i] * vyz);
-                        val -= fibo[i] * eta * eta * eta * dxyz[i] * vxyz;
+                        auto u = uvals[i];
+                        val += fibo[i] * (u.val * v.val + eta * form(u, v));
                     }
 
                     U(aa[0], aa[1], aa[2]) += val * w * J;

--- a/examples/multistep/multistep3d.hpp
+++ b/examples/multistep/multistep3d.hpp
@@ -78,13 +78,6 @@ private:
         prepare_spaces();
         prepare_matrices();
 
-        // Single initial step is enough only for two-step methods
-
-        // auto init = [this](double x, double y) { return init_state(x, y); };
-        // projection(us[0], init);
-        // apply_bc(us[0]);
-        // solve(us[0]);
-
         int needed = us.size() - 1;
         for (int i = 0; i < needed; ++i) {
             double t = i * steps.dt;
@@ -96,8 +89,6 @@ private:
             apply_bc(us[0]);
             solve(us[0]);
 
-            // std::cout << "Initial state " << t << " ";
-            // print_errors(us[0], t);
             us.rotate();
         }
         us.rotate();
@@ -324,8 +315,6 @@ private:
             e * M_PI * std::sin(x * M_PI) * std::sin(y * M_PI) * std::cos(z * M_PI),
         };
     }
-
-    double init_state(double x, double y, double z) const { return solution(x, y, z, 0).val; }
 };
 
 }  // namespace ads::problems

--- a/examples/multistep/multistep_base.hpp
+++ b/examples/multistep/multistep_base.hpp
@@ -77,6 +77,20 @@ protected:
             f[i] = buf(d - 1, i);
         }
     }
+
+    template <typename SolutionList>
+    void adjust_solution(SolutionList& us) {
+        auto const dof_count = us[0].size();
+        auto* u = us[0].data();
+
+        for (int i = 1; i < order; ++i) {
+            auto const* u_old = us[i].data();
+
+            for (int j = 0; j < dof_count; ++j) {
+                u[j] -= fibo[i] * u_old[j];
+            }
+        }
+    }
 };
 
 }  // namespace problems


### PR DESCRIPTION
In the multistep code, we start with a linear multistep method

<img src="https://render.githubusercontent.com/render/math?math=(M%20%2B%20%5Ceta%20K)u_n%20%3D%20%5Ctext%7BRHS%7D(u_%7Bn-1%7D%2C%5Cldots%2Cu_%7Bn-k%7D)">

We want to replace <img src="https://render.githubusercontent.com/render/math?math=M%20%2B%20%5Ceta%20K"> with <img src="https://render.githubusercontent.com/render/math?math=%5Ctilde%7BM%7D%20%3D%20(M_x%20%2B%20%5Ceta%20K_x)%20%5Cotimes%20(M_y%20%2B%20%5Ceta%20K_y)"> to use ADS solver, but this introduces <img src="https://render.githubusercontent.com/render/math?math=O(%5Ctau%5E2)"> error in each time step, which reduces the order of method to 1, making it pointless to go for higher order schemes.

To prevent that, we add some stuff to both sides so that <img src="https://render.githubusercontent.com/render/math?math=M%20%2B%20%5Ceta%20K"> is applied to a small quantity. For example, <img src="https://render.githubusercontent.com/render/math?math=u_n%20-%202u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D"> is of order <img src="https://render.githubusercontent.com/render/math?math=O(%5Ctau%5E2)">, so we can construct a third order method starting with

<img src="https://render.githubusercontent.com/render/math?math=(M%20%2B%20%5Ceta%20K)(u_n%20-%202u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D)%20%3D%20%5Ctext%7BRHS%7D(u_%7Bn-1%7D%2C%5Cldots%2Cu_%7Bn-k%7D)%20%2B%20(M%20%2B%20%5Ceta%20K)(-2u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D)">

and replacing <img src="https://render.githubusercontent.com/render/math?math=M%20%2B%20%5Ceta%20K"> with <img src="https://render.githubusercontent.com/render/math?math=%5Ctilde%7BM%7D">:

<img src="https://render.githubusercontent.com/render/math?math=%5Ctilde%7BM%7D(u_n%20-%202u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D)%20%3D%20%5Ctext%7BRHS%7D(u_%7Bn-1%7D%2C%5Cldots%2Cu_%7Bn-k%7D)%20%2B%20(M%20%2B%20%5Ceta%20K)(-2u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D)">

In the previous version of the code, we would move everything except for <img src="https://render.githubusercontent.com/render/math?math=u_n"> to the right-hand side and end up with

<img src="https://render.githubusercontent.com/render/math?math=%5Ctilde%7BM%7Du_n%20%3D%20%5Ctext%7BRHS%7D(u_%7Bn-1%7D%2C%5Cldots%2Cu_%7Bn-k%7D)%20-%20%5Ceta%5E2%20K_x%20%5Cotimes%20K_y%20(-2u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D)">

since <img src="https://render.githubusercontent.com/render/math?math=M%20%2B%20%5Ceta%20K%20-%20%5Ctilde%7BM%7D%20%3D%20-%20%5Ceta%5E2%20K_x%20%5Cotimes%20K_y">. This is, however, a bad idea, since the bilinear form associated with <img src="https://render.githubusercontent.com/render/math?math=K_x%20%5Cotimes%20K_y"> is unnatural and difficult to evaluate (requires mixed derivatives), especially in 3D. Instead, it is better to solve for <img src="https://render.githubusercontent.com/render/math?math=%5Cmathcal%7BU%7D%20%3D%20u_n%20-%202u_%7Bn-1%7D%20%2B%20u_%7Bn-2%7D"> and compute <img src="https://render.githubusercontent.com/render/math?math=u_n"> from it.

Closes #59 