### PR TITLE
Fix tensor `for_each` iteration function

### DIFF
--- a/include/ads/lin/tensor/for_each.hpp
+++ b/include/ads/lin/tensor/for_each.hpp
@@ -18,7 +18,7 @@ struct tensor_helper {
 
     template <typename F>
     static void for_each_multiindex(F&& fun, const Tensor& t, Indices... indices) {
-        auto size = t.size(I);
+        auto size = t.size(Rank - 1 - I);
         for (int i = 0; i < size; ++i) {
             Next::for_each_multiindex(std::forward<F>(fun), t, i, indices...);
         }


### PR DESCRIPTION
Sizes for each dimension were taken in the opposite order. This was not
detected earlier, since this function is only used to iterate over
output values array, which always has the same size in each dimension.

Closes #72