### PR TITLE
tests: Resolve compilation error linked to Catch2

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -99,7 +99,7 @@ cmake --install Galois/build --component lib
 cmake --install Galois/build --component tools
 
 # Install Catch2
-CATCH2_VER=2.13.6
+CATCH2_VER=3.3.2
 curl -sL https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VER}.tar.gz -o catch2.tar.gz
 tar xzf catch2.tar.gz
 mv Catch2-${CATCH2_VER} Catch2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,6 @@ set_target_properties(ads-suite PROPERTIES OUTPUT_NAME suite)
 
 target_sources(ads-suite
   PRIVATE
-    main.cpp
     ads/bspline/bspline_test.cpp
     ads/bspline/eval_test.cpp
     ads/basis_data_test.cpp
@@ -26,6 +25,6 @@ target_sources(ads-suite
 
 target_include_directories(ads-suite PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(ads-suite PRIVATE ads-objects ads-options-private Catch2::Catch2)
+target_link_libraries(ads-suite PRIVATE ads-objects ads-options-private Catch2::Catch2WithMain)
 
 catch_discover_tests(ads-suite PROPERTIES LABELS "ADS")

--- a/tests/ads/basis_data_test.cpp
+++ b/tests/ads/basis_data_test.cpp
@@ -3,7 +3,7 @@
 
 #include "ads/basis_data.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "ads/bspline/bspline.hpp"
 

--- a/tests/ads/bspline/bspline_test.cpp
+++ b/tests/ads/bspline/bspline_test.cpp
@@ -3,7 +3,7 @@
 
 #include "ads/bspline/bspline.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 namespace bsp = ads::bspline;
 using Catch::Matchers::Equals;

--- a/tests/ads/bspline/eval_test.cpp
+++ b/tests/ads/bspline/eval_test.cpp
@@ -3,12 +3,13 @@
 
 #include <numeric>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "ads/bspline/bspline.hpp"
 #include "ads/util.hpp"
 
 namespace bsp = ads::bspline;
+using Catch::Approx;
 
 TEST_CASE("B-spline evaluation", "[splines]") {
     const int p = 2;

--- a/tests/ads/lin/band_solve_test.cpp
+++ b/tests/ads/lin/band_solve_test.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "ads/lin/band_matrix.hpp"
 #include "ads/lin/tensor.hpp"

--- a/tests/ads/lin/dense_solve_test.cpp
+++ b/tests/ads/lin/dense_solve_test.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "ads/lin/dense_matrix.hpp"
 #include "ads/lin/tensor.hpp"

--- a/tests/ads/lin/tensor_test.cpp
+++ b/tests/ads/lin/tensor_test.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 namespace lin = ads::lin;
 

--- a/tests/ads/solver_test.cpp
+++ b/tests/ads/solver_test.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "ads/lin/band_matrix.hpp"
 #include "ads/lin/band_solve.hpp"

--- a/tests/ads/util/multi_array_test.cpp
+++ b/tests/ads/util/multi_array_test.cpp
@@ -3,7 +3,7 @@
 
 #include "ads/util/multi_array.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using Catch::Matchers::Equals;
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2015 - 2023 Marcin Łoś <marcin.los.91@gmail.com>
-// SPDX-License-Identifier: MIT
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>


### PR DESCRIPTION
Compilation of IGA-ADS with Catch2 v3 terminates with several errors:

iga-ads/tests/main.cpp:5:10: fatal error: catch2/catch.hpp: No such file or directory
    5 | #include <catch2/catch.hpp>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.

Error vanishes when compiling with Catch2 v2.x branch because v3 renamed catch2/catch.hpp to catch2/catch_all.hpp. Upgrade IGA-ADS to support v3 in order to resolve this error. In tests/, replace every occurence of catch2/catch.hpp with catch2/catch_all.hpp and Approx with Catch::Approx, remove main.cpp and link against Catch::Catch2WithMain instead of Catch::Catch2. Tested on Fedora 36.